### PR TITLE
By default, do *not* write timezone offset in CSV. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gridworks-debug-cli"
-version = "0.2.4"
+version = "0.2.5"
 description = "Gridworks Debug Cli"
 authors = ["Andrew Schweitzer <schweitz72@gmail.com>"]
 license = "MIT"

--- a/src/gwdcli/csv/egauge_download.py
+++ b/src/gwdcli/csv/egauge_download.py
@@ -209,8 +209,8 @@ def egauge_download(
         "--local-time",
         help="Convert downloaded times from UTC to local times before writing CSV",
     ),
-    no_tz: bool = typer.Option(
-        False, "--no-tz", help="Strip timezone offset from datetimes in CSV"
+    write_tz: bool = typer.Option(
+        False, "-z", "--write-tz", help="Write timezone offset from UTC in the CSV"
     ),
     raw: bool = typer.Option(
         False,
@@ -278,7 +278,7 @@ def egauge_download(
         df.index = df.index.tz_localize("UTC")
         if local_time:
             df.index = df.index.tz_convert(pendulum.now().timezone.name)
-        if no_tz:
+        if not write_tz:
             df.index = df.index.tz_localize(None)
         if code == 200:
             if thirsty_run:


### PR DESCRIPTION
Use --write-tz / -z to write the timzeon offset